### PR TITLE
Fix integer overflow (memtest) issue

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2021-05-31.
-Once it is accepted, delete this file and tag the release (commit 83aa69f).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2021-06-02.
+Once it is accepted, delete this file and tag the release (commit 0703044).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2021-06-01.
-Once it is accepted, delete this file and tag the release (commit 793cecb).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2021-06-01.
+Once it is accepted, delete this file and tag the release (commit 793cecb).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2021-05-31.
+Once it is accepted, delete this file and tag the release (commit 83aa69f).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# spectre 1.0.1
+
+- A number of minor bug fixes aimed at ensuring all CRAN build checks on all systems work
+
 # spectre 1.0
 
 - First submission to CRAN

--- a/R/run_optimization_min_conf.R
+++ b/R/run_optimization_min_conf.R
@@ -64,7 +64,7 @@ run_optimization_min_conf <- function(alpha_list,
   }
   
   if (is.na(seed)) {
-    seed <- Sys.getpid() # sample(0:.Machine$integer.max, 1)
+    seed <- sample.int(.Machine$integer.max, 1)
   }
   
   # we need the upper triangle of the target matrix, only

--- a/R/run_optimization_min_conf.R
+++ b/R/run_optimization_min_conf.R
@@ -8,7 +8,7 @@
 #' @param total_gamma Total number of species present throughout the entire
 #'  landscape.
 #' @param target Pairwise matrix of species in common between each site by site 
-#'  pair.
+#'  pair. Only the upper triangle of the matrix is actually needed.
 #' @param fixed_species Fixed partial solution with species that are considered 
 #'  as given. Those species are not going to be changed during optimization.
 #' @param partial_solution An initial \code{matrix} of species presences and 

--- a/R/run_optimization_min_conf.R
+++ b/R/run_optimization_min_conf.R
@@ -68,8 +68,7 @@ run_optimization_min_conf <- function(alpha_list,
   }
   
   # we need the upper triangle of the target matrix, only
-  target[lower.tri(target, diag = TRUE)] <- NA
-  
+  # the lower triangle including the diagonal is set NA in the optimizer.
   result = optimizer_min_conf(alpha_list = alpha_list, 
                               total_gamma = total_gamma, 
                               target = target, 

--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,7 @@ knitr::opts_chunk$set(
 [![Codecov](https://codecov.io/gh/r-spatialecology/spectre/branch/main/graph/badge.svg)](https://codecov.io/gh/r-spatialecology/spectre?branch=main)
 
 [![CRAN status](https://www.r-pkg.org/badges/version/spectre)](https://CRAN.R-project.org/package=spectre)
-[![CRAN logs](https://cranlogs.r-pkg.org/badges/grand-total/spectre)](https://cran.rstudio.com/web/packages/spectre/index.html)
+[![CRAN logs](https://cranlogs.r-pkg.org/badges/grand-total/spectre)](https://CRAN.R-project.org/package=spectre)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) 
 <!-- badges: end -->

--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,7 @@ knitr::opts_chunk$set(
 [![Codecov](https://codecov.io/gh/r-spatialecology/spectre/branch/main/graph/badge.svg)](https://codecov.io/gh/r-spatialecology/spectre?branch=main)
 
 [![CRAN status](https://www.r-pkg.org/badges/version/spectre)](https://CRAN.R-project.org/package=spectre)
-[![CRAN logs](http://cranlogs.r-pkg.org/badges/grand-total/spectre)](http://cran.rstudio.com/web/packages/spectre/index.html)
+[![CRAN logs](https://cranlogs.r-pkg.org/badges/grand-total/spectre)](https://cran.rstudio.com/web/packages/spectre/index.html)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) 
 <!-- badges: end -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
+
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-spectre
-=======
+# spectre
 
 <img src="man/figures/spectre.png" align="right" width="150" />
 
@@ -18,7 +18,7 @@ stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://
 [![CRAN
 status](https://www.r-pkg.org/badges/version/spectre)](https://CRAN.R-project.org/package=spectre)
 [![CRAN
-logs](http://cranlogs.r-pkg.org/badges/grand-total/spectre)](http://cran.rstudio.com/web/packages/spectre/index.html)
+logs](https://cranlogs.r-pkg.org/badges/grand-total/spectre)](https://cran.rstudio.com/web/packages/spectre/index.html)
 
 [![License: GPL
 v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -28,31 +28,32 @@ The goal of `spectre` is to provide an open source tool capable of
 predicting regional community composition at fine spatial resolutions
 using only sparse biological and environmental data.
 
-Installation
-------------
+## Installation
 
 Install the release version from CRAN:
 
-    install.packages("spectre")
+``` r
+install.packages("spectre")
+```
 
 To install the developmental version of `spectre`, use:
 
-    install.packages("remotes")
-    remotes::install_github("r-spatialecology/spectre")
+``` r
+install.packages("remotes")
+remotes::install_github("r-spatialecology/spectre")
+```
 
 A full use case example is included in the “Getting started with
 spectre” vignette associated with the package.
 
-Meta
-----
+## Meta
 
 -   Please [report any issues or
     bugs](https://github.com/r-spatialecology/spectre/issues/new).
 -   Get citation information for `spectre` in R doing
     `citation(package = 'spectre')`
 
-Code of Conduct
----------------
+## Code of Conduct
 
 Please note that the spectre project is released with a [Contributor
 Code of

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
+
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-spectre
-=======
+# spectre
 
 <img src="man/figures/spectre.png" align="right" width="150" />
 
@@ -18,7 +18,7 @@ stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://
 [![CRAN
 status](https://www.r-pkg.org/badges/version/spectre)](https://CRAN.R-project.org/package=spectre)
 [![CRAN
-logs](https://cranlogs.r-pkg.org/badges/grand-total/spectre)](https://cran.rstudio.com/web/packages/spectre/index.html)
+logs](https://cranlogs.r-pkg.org/badges/grand-total/spectre)](https://CRAN.R-project.org/package=spectre)
 
 [![License: GPL
 v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -28,31 +28,32 @@ The goal of `spectre` is to provide an open source tool capable of
 predicting regional community composition at fine spatial resolutions
 using only sparse biological and environmental data.
 
-Installation
-------------
+## Installation
 
 Install the release version from CRAN:
 
-    install.packages("spectre")
+``` r
+install.packages("spectre")
+```
 
 To install the developmental version of `spectre`, use:
 
-    install.packages("remotes")
-    remotes::install_github("r-spatialecology/spectre")
+``` r
+install.packages("remotes")
+remotes::install_github("r-spatialecology/spectre")
+```
 
 A full use case example is included in the “Getting started with
 spectre” vignette associated with the package.
 
-Meta
-----
+## Meta
 
 -   Please [report any issues or
     bugs](https://github.com/r-spatialecology/spectre/issues/new).
 -   Get citation information for `spectre` in R doing
     `citation(package = 'spectre')`
 
-Code of Conduct
----------------
+## Code of Conduct
 
 Please note that the spectre project is released with a [Contributor
 Code of

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,24 @@
+# spectre 1.0.1 
+
+## Resubmission
+This is a resubmission. Below is a list of changes made to address each comment:
+
+Found the following (possibly) invalid URLs:
+URL: http://cran.rstudio.com/web/packages/spectre/index.html (moved to https://cran.rstudio.com/web/packages/spectre/index.html)
+From: README.md
+Status: 200
+Message: OK
+CRAN URL not in canonical form
+
+Canonical: https://CRAN.R-project.org/package=spectre
+
+Please fix and resubmit.
+
+
+* The link was updated
+
+---
+
 Update Version: 1.0.1
 
 Update addresses 2 notes and 1 error discovered by CRAN package check run 2021-05-30 23:49:52 CEST. Solutions to points brought up are listed below:

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,25 @@
 # spectre 1.0.1 
 
 ## Resubmission
+This is a second resubmission. Below is a list of changes made to address each comment:
+
+   Found the following (possibly) invalid URLs:
+     URL: https://cran.rstudio.com/web/packages/spectre/index.html
+       From: README.md
+       Status: 200
+       Message: OK
+       CRAN URL not in canonical form
+
+Please fix and resubmit.
+
+
+* The link was updated, to the https canonical form 
+
+---
+
+# spectre 1.0.1 
+
+## Resubmission
 This is a resubmission. Below is a list of changes made to address each comment:
 
 Found the following (possibly) invalid URLs:

--- a/man/run_optimization_min_conf.Rd
+++ b/man/run_optimization_min_conf.Rd
@@ -24,7 +24,7 @@ each cell.}
 landscape.}
 
 \item{target}{Pairwise matrix of species in common between each site by site
-pair.}
+pair. Only the upper triangle of the matrix is actually needed.}
 
 \item{max_iterations}{The maximum number of iterations that the optimization
 algorithm may run through before stopping.}

--- a/spectre.Rproj
+++ b/spectre.Rproj
@@ -14,6 +14,6 @@ LaTeX: pdfLaTeX
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageInstallArgs: --no-multiarch --with-keep.source
+PackageInstallArgs: --no-multiarch --with-keep.source --preclean --install-tests
 PackageCheckArgs: --no-multiarch --as-cran
 PackageRoxygenize: rd,collate,namespace,vignette

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -36,12 +36,12 @@ BEGIN_RCPP
 END_RCPP
 }
 
-RcppExport SEXP run_testthat_tests();
+RcppExport SEXP run_testthat_tests(SEXP use_xml_sxp);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_spectre_optimizer_min_conf", (DL_FUNC) &_spectre_optimizer_min_conf, 9},
     {"_spectre_calculate_solution_commonness_rcpp", (DL_FUNC) &_spectre_calculate_solution_commonness_rcpp, 1},
-    {"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 0},
+    {"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 1},
     {NULL, NULL, 0}
 };
 

--- a/src/minconf.cpp
+++ b/src/minconf.cpp
@@ -33,8 +33,9 @@ MinConf::MinConf(const std::vector<unsigned> &alpha_list,
     commonness[site].resize(n_sites, NA);
 
     // convert target matrix to a more convenient format
-    this->target[site].resize(n_sites);
-    for (unsigned other_site = 0; other_site < n_sites; other_site++) {
+    this->target[site].resize(n_sites, NA);
+    // iterate over the upper triagonal matrix, only (w/o diagonal)
+    for (unsigned other_site = site + 1; other_site < n_sites; other_site++) {
       if (target[other_site * n_sites + site] == NA) {
         this->target[site][other_site] = NA;
       } else {
@@ -322,8 +323,9 @@ unsigned MinConf::calc_error() {
       if (target[site][other_site] == NA) {
         continue;
       }
-      sum_diff +=
+      auto tmp =
           std::abs(commonness[site][other_site] - target[site][other_site]);
+      sum_diff += tmp;
     }
   }
   return sum_diff;

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -43,7 +43,7 @@ List optimizer_min_conf(const IntegerVector alpha_list,
         *std::max_element(mc.error_vector.begin(), mc.error_vector.end());
     Rcout << "\n > Optimization finished with lowest absolute error = "
           << best_error << " (highest absolute error was: " << worst_error
-          << " improved by: " << worst_error - best_error << ")";
+          << " improved by: " << worst_error - best_error << ") \n";
   }
 
   return (results);

--- a/src/test-minconf.cpp
+++ b/src/test-minconf.cpp
@@ -4,158 +4,176 @@
 
 void TestMinConf::test_add_species_min_conf(
     unsigned site, const std::vector<std::vector<int>> &target) {
-  this->target = target;
-  add_species_min_conf(site);
+    setTarget(target);
+    add_species_min_conf(site);
 }
 
 std::vector<unsigned> TestMinConf::test_calc_min_conflict_species(
     const unsigned site, const std::vector<std::vector<int>> &target) {
-  this->target = target;
-  return calc_min_conflict_species(site);
+    setTarget(target);
+    return calc_min_conflict_species(site);
 }
 
 void TestMinConf::test_update_solution_commonness() {
-  update_solution_commonness();
+    update_solution_commonness();
 }
 
 double
 TestMinConf::test_calc_error(const std::vector<std::vector<int>> &commonness,
                              const std::vector<std::vector<int>> &target) {
-  this->commonness = commonness;
-  this->target = target;
-  return calc_error();
+    setCommonness(commonness);
+    setTarget(target);
+    return calc_error();
 }
 
 std::vector<unsigned> TestMinConf::test_calc_missing_species() {
-  return calc_missing_species();
+    return calc_missing_species();
 }
 
 std::vector<std::vector<int>> TestMinConf::getTarget() const { return target; }
 
+void TestMinConf::setTarget(const std::vector<std::vector<int> > new_target)
+{
+    for (unsigned site = 0; site < n_sites; site++) {
+        for (unsigned other_site = site + 1; other_site < n_sites; other_site++) {
+            this->target[site][other_site] = new_target[site][other_site];
+        }
+    }
+}
+
+void TestMinConf::setCommonness(const std::vector<std::vector<int> > new_commonness)
+{
+    for (unsigned site = 0; site < n_sites; site++) {
+        for (unsigned other_site = site + 1; other_site < n_sites; other_site++) {
+            this->commonness[site][other_site] = new_commonness[site][other_site];
+        }
+    }
+}
+
 context("MinConf does not skrew up the target") {
-  std::random_device rd;
-  long long seed = rd();
-  std::vector<unsigned> alpha_list = {14, 12, 8};
-  unsigned gamma = 30;
+    std::random_device rd;
+    long long seed = rd();
+    std::vector<unsigned> alpha_list = {14, 12, 8};
+    unsigned gamma = 30;
 
-  std::vector<int> target = {TestMinConf::NA,
-                             TestMinConf::NA,
-                             TestMinConf::NA,
-                             5,
-                             TestMinConf::NA,
-                             TestMinConf::NA,
-                             3,
-                             4,
-                             TestMinConf::NA};
+    std::vector<int> target = {TestMinConf::NA,
+                               TestMinConf::NA,
+                               TestMinConf::NA,
+                               5,
+                               TestMinConf::NA,
+                               TestMinConf::NA,
+                               3,
+                               4,
+                               TestMinConf::NA};
 
-  std::vector<std::vector<int>> expected_target = {
-      {TestMinConf::NA, 5, 3},
-      {TestMinConf::NA, TestMinConf::NA, 4},
-      {TestMinConf::NA, TestMinConf::NA, TestMinConf::NA}};
+    std::vector<std::vector<int>> expected_target = {
+        {TestMinConf::NA, 5, 3},
+        {TestMinConf::NA, TestMinConf::NA, 4},
+        {TestMinConf::NA, TestMinConf::NA, TestMinConf::NA}};
 
-  TestMinConf min_conf(alpha_list, gamma, target, std::vector<int>(),
-                       std::vector<int>(), seed);
-  auto calc_target = min_conf.getTarget();
-  expect_true(calc_target == expected_target);
+    TestMinConf min_conf(alpha_list, gamma, target, std::vector<int>(),
+                         std::vector<int>(), seed);
+    auto calc_target = min_conf.getTarget();
+    expect_true(calc_target == expected_target);
 }
 
 context("MinConf does use the upper triangle of the target matrix, only") {
-  std::random_device rd;
-  long long seed = 0;
-  std::vector<unsigned> alpha_list = {14, 12, 8};
-  unsigned gamma = 30;
+    std::random_device rd;
+    long long seed = 0;
+    std::vector<unsigned> alpha_list = {14, 12, 8};
+    unsigned gamma = 30;
 
-  std::vector<int> target = {0, 0, 0, 5, 0, 0, 3, 4, 0};
+    std::vector<int> target = {7, 12, 0, 5, -333, 9, 3, 4, -123};
 
-  std::vector<std::vector<int>> expected_target = {
-      {TestMinConf::NA, 5, 3},
-      {TestMinConf::NA, TestMinConf::NA, 4},
-      {TestMinConf::NA, TestMinConf::NA, TestMinConf::NA}};
+    std::vector<std::vector<int>> expected_target = {
+        {TestMinConf::NA, 5, 3},
+        {TestMinConf::NA, TestMinConf::NA, 4},
+        {TestMinConf::NA, TestMinConf::NA, TestMinConf::NA}};
 
-  TestMinConf min_conf(alpha_list, gamma, target, std::vector<int>(),
-                       std::vector<int>(), seed);
-  auto calc_target = min_conf.getTarget();
-  expect_true(calc_target == expected_target);
+    TestMinConf min_conf(alpha_list, gamma, target, std::vector<int>(),
+                         std::vector<int>(), seed);
+    auto calc_target = min_conf.getTarget();
+    expect_true(calc_target == expected_target);
 }
 
 context("Tests for the MinConf class") {
-  std::random_device rd;
-  long long seed = rd();
-  std::vector<unsigned> alpha_list = {2, 1, 2};
-  unsigned gamma = 3;
-  std::vector<int> target = {-10, 0, 2, 0, -10, 0, 2, 0, -10};
+    std::random_device rd;
+    long long seed = rd();
+    std::vector<unsigned> alpha_list = {2, 1, 2};
+    unsigned gamma = 3;
+    std::vector<int> target = {-10, 0, 2, 0, -10, 0, 2, 0, -10};
 
-  test_that("calc_missing_species()") {
+    test_that("calc_missing_species()") {
+        TestMinConf mc(alpha_list, gamma, target, std::vector<int>(),
+                       std::vector<int>(), seed);
+        mc.solution = {{1, 1, 1}, {0, 0, 0}, {1, 0, 0}};
+        const auto missing_species = mc.test_calc_missing_species();
+
+        expect_true(missing_species.size() == 3);
+        expect_true(missing_species[0] == 0);
+        expect_true(missing_species[1] == 1);
+        expect_true(missing_species[2] == 1);
+    }
+
     TestMinConf mc(alpha_list, gamma, target, std::vector<int>(),
                    std::vector<int>(), seed);
-    mc.solution = {{1, 1, 1}, {0, 0, 0}, {1, 0, 0}};
-    const auto missing_species = mc.test_calc_missing_species();
+    mc.solution = {{0, 1, 1}, {1, 0, 0}, {0, 1, 1}};
 
-    expect_true(missing_species.size() == 3);
-    expect_true(missing_species[0] == 0);
-    expect_true(missing_species[1] == 1);
-    expect_true(missing_species[2] == 1);
-  }
-
-  TestMinConf mc(alpha_list, gamma, target, std::vector<int>(),
-                 std::vector<int>(), seed);
-  mc.solution = {{0, 1, 1}, {1, 0, 0}, {0, 1, 1}};
-
-  test_that("calc_error() ") {
-    std::vector<std::vector<int>> commonness = {{TestMinConf::NA, 2, 2},
+    test_that("calc_error() ") {
+        std::vector<std::vector<int>> commonness = {{TestMinConf::NA, 2, 2},
+                                                    {2, TestMinConf::NA, 3},
+                                                    {2, 3, TestMinConf::NA}};
+        std::vector<std::vector<int>> target = {{TestMinConf::NA, 2, 2},
                                                 {2, TestMinConf::NA, 3},
                                                 {2, 3, TestMinConf::NA}};
-    std::vector<std::vector<int>> target = {{TestMinConf::NA, 2, 2},
-                                            {2, TestMinConf::NA, 3},
-                                            {2, 3, TestMinConf::NA}};
 
-    expect_true(mc.test_calc_error(commonness, target) == Approx(0.0));
-    target[2][1] = 2;
-    expect_true(mc.test_calc_error(commonness, target) == Approx(1.0));
-    commonness[0][1] = 5;
-    expect_true(mc.test_calc_error(commonness, target) == Approx(4.0));
-  }
+        expect_true(mc.test_calc_error(commonness, target) == Approx(0.0));
+        target[1][2] = 2;
+        expect_true(mc.test_calc_error(commonness, target) == Approx(1.0));
+        commonness[0][1] = 5;
+        expect_true(mc.test_calc_error(commonness, target) == Approx(4.0));
+    }
 
-  test_that("calculate_commonness()") {
-    std::vector<std::vector<int>> commonness = {
-        {TestMinConf::NA, 0, 2},
-        {TestMinConf::NA, TestMinConf::NA, 0},
-        {TestMinConf::NA, TestMinConf::NA, TestMinConf::NA}};
-    mc.test_update_solution_commonness();
-    expect_true(mc.commonness == commonness);
-  }
+    test_that("calculate_commonness()") {
+        std::vector<std::vector<int>> commonness = {
+            {TestMinConf::NA, 0, 2},
+            {TestMinConf::NA, TestMinConf::NA, 0},
+            {TestMinConf::NA, TestMinConf::NA, TestMinConf::NA}};
+        mc.test_update_solution_commonness();
+        expect_true(mc.commonness == commonness);
+    }
 
-  test_that("calc_min_conflict_species") {
-    mc.solution = {{0, 1, 1}, {1, 0, 0}, {0, 1, 1}};
-    unsigned site = 1;
-    std::vector<unsigned> absent_species = {1, 2};
-    std::vector<std::vector<int>> target = {{TestMinConf::NA, 0, 2},
-                                            {0, TestMinConf::NA, 0},
-                                            {2, 0, TestMinConf::NA}};
-    expect_true(mc.test_calc_min_conflict_species(site, target) ==
-                absent_species);
-    mc.solution = {{0, 1, 1}, {0, 1, 0}, {0, 1, 1}};
-    absent_species[0] = 0;
-    expect_true(mc.test_calc_min_conflict_species(site, target) ==
-                std::vector<unsigned>{0});
-  }
+    test_that("calc_min_conflict_species") {
+        mc.solution = {{0, 1, 1}, {1, 0, 0}, {0, 1, 1}};
+        unsigned site = 1;
+        std::vector<unsigned> absent_species = {1, 2};
+        std::vector<std::vector<int>> target = {{TestMinConf::NA, 0, 2},
+                                                {0, TestMinConf::NA, 0},
+                                                {2, 0, TestMinConf::NA}};
+        expect_true(mc.test_calc_min_conflict_species(site, target) ==
+                    absent_species);
+        mc.solution = {{0, 1, 1}, {0, 1, 0}, {0, 1, 1}};
+        absent_species[0] = 0;
+        expect_true(mc.test_calc_min_conflict_species(site, target) ==
+                    std::vector<unsigned>{0});
+    }
 
-  test_that("add_species_min_conf") {
-    unsigned site = 0;
-    mc.solution = {{0, 0, 1}, {1, 0, 0}, {0, 1, 1}};
-    std::vector<std::vector<int>> expected_solution = {
-        {0, 1, 1}, {1, 0, 0}, {0, 1, 1}};
-    std::vector<std::vector<int>> target = {{TestMinConf::NA, 0, 2},
-                                            {0, TestMinConf::NA, 0},
-                                            {2, 0, TestMinConf::NA}};
-    mc.test_add_species_min_conf(site, target);
-    expect_true(mc.solution == expected_solution);
-    mc.test_add_species_min_conf(site, target);
-    expected_solution = {{1, 1, 1}, {1, 0, 0}, {0, 1, 1}};
-    expect_true(mc.solution == expected_solution);
-    mc.test_add_species_min_conf(site, target);
-    expect_true(mc.solution == expected_solution);
-  }
+    test_that("add_species_min_conf") {
+        unsigned site = 0;
+        mc.solution = {{0, 0, 1}, {1, 0, 0}, {0, 1, 1}};
+        std::vector<std::vector<int>> expected_solution = {
+            {0, 1, 1}, {1, 0, 0}, {0, 1, 1}};
+        std::vector<std::vector<int>> target = {{TestMinConf::NA, 0, 2},
+                                                {0, TestMinConf::NA, 0},
+                                                {2, 0, TestMinConf::NA}};
+        mc.test_add_species_min_conf(site, target);
+        expect_true(mc.solution == expected_solution);
+        mc.test_add_species_min_conf(site, target);
+        expected_solution = {{1, 1, 1}, {1, 0, 0}, {0, 1, 1}};
+        expect_true(mc.solution == expected_solution);
+        mc.test_add_species_min_conf(site, target);
+        expect_true(mc.solution == expected_solution);
+    }
 }
 
 #endif

--- a/src/test-minconf.cpp
+++ b/src/test-minconf.cpp
@@ -59,6 +59,25 @@ context("MinConf does not skrew up the target") {
   expect_true(calc_target == expected_target);
 }
 
+context("MinConf does use the upper triangle of the target matrix, only") {
+  std::random_device rd;
+  long long seed = 0;
+  std::vector<unsigned> alpha_list = {14, 12, 8};
+  unsigned gamma = 30;
+
+  std::vector<int> target = {0, 0, 0, 5, 0, 0, 3, 4, 0};
+
+  std::vector<std::vector<int>> expected_target = {
+      {TestMinConf::NA, 5, 3},
+      {TestMinConf::NA, TestMinConf::NA, 4},
+      {TestMinConf::NA, TestMinConf::NA, TestMinConf::NA}};
+
+  TestMinConf min_conf(alpha_list, gamma, target, std::vector<int>(),
+                       std::vector<int>(), seed);
+  auto calc_target = min_conf.getTarget();
+  expect_true(calc_target == expected_target);
+}
+
 context("Tests for the MinConf class") {
   std::random_device rd;
   long long seed = rd();

--- a/src/test-minconf.h
+++ b/src/test-minconf.h
@@ -17,6 +17,8 @@ public:
   double test_calc_error(const std::vector<std::vector<int>> &commonness,
                          const std::vector<std::vector<int>> &target);
   std::vector<std::vector<int>> getTarget() const;
+  void setTarget(const std::vector<std::vector<int>> new_target);
+  void setCommonness(const std::vector<std::vector<int>> new_commonness);
   std::vector<unsigned> test_calc_missing_species();
   static const int NA = -2147483648; // Rcpp NA_INTEGER == R_NaInt
 };


### PR DESCRIPTION
We indeed had an issue with an integer overflow. It happened because we assume in the C++ code that the target matrix is NA in the lower triangle including the diagonal. This structure was originally ensured in the R code but got messed up in C++ later. I, therefore, moved the part where the lower triangle is set NA to the C++ constructor of the MinConf class.