### PR TITLE
:zap: run_optimization_min_conf now allows the continuation of a prev…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,6 @@ ByteCompile: true
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 SystemRequirements: C++11
 VignetteBuilder: knitr

--- a/R/run_optimization_min_conf.R
+++ b/R/run_optimization_min_conf.R
@@ -11,16 +11,20 @@
 #'  pair. Only the upper triangle of the matrix is actually needed.
 #' @param fixed_species Fixed partial solution with species that are considered 
 #'  as given. Those species are not going to be changed during optimization.
-#' @param partial_solution An initial \code{matrix} of species presences and 
+#' @param partial_solution Can be either the result of a previous optimization 
+#' run (see \code{value}) or an (initial) \code{matrix} of species presences and 
 #'  absences for each site in the landscape. The total number of presences must
-#'  match the estimated species richness of each site.
+#'  match the estimated species richness of each site. If a result of a previous 
+#'  optimization is used, its \code{optimized_grid} is used as initial matrix and
+#'  its \code{error} data frame will be extended with the new iterations.
 #' @param max_iterations The maximum number of iterations that the optimization
 #'  algorithm may run through before stopping.
 #' @param seed Seed for random number generator. Seed must be a positive integer value.
 #'   \code{seed = NA} means that a random integer is used as seed. 
 #' @param verbose If \code{TRUE} (default), a progress report is printed during
 #'  the optimization run. 
-#' @param interruptible Allow a run to be interrupted before completion.
+#' @param interruptible Allow a run to be interrupted before completion. 
+#' \code{FALSE} increases the performance.#' 
 #' 
 #' @details \code{run_optimization_min_conf} is the core function of the 
 #'  \code{spectre} package. The underlying algorithm of this function is
@@ -59,8 +63,12 @@ run_optimization_min_conf <- function(alpha_list,
     fixed_species <- matrix()
   }
   
+  previous_iterations <- NA
   if (is.null(partial_solution)) {
     partial_solution <- matrix()
+  } else if (is.list(partial_solution)) {
+    previous_iterations <- partial_solution$error
+    partial_solution <- partial_solution$optimized_grid
   }
   
   if (is.na(seed)) {
@@ -78,6 +86,11 @@ run_optimization_min_conf <- function(alpha_list,
                               seed = seed, 
                               verbose = verbose,
                               interruptible = interruptible)
+  
+  if (length(previous_iterations) > 1) {
+    result$error <- rbind(previous_iterations, result$error[-1,])
+    result$error$i <- 0:(nrow(result$error) - 1)
+  }
   
   return(result)
 }

--- a/man/run_optimization_min_conf.Rd
+++ b/man/run_optimization_min_conf.Rd
@@ -29,9 +29,12 @@ pair. Only the upper triangle of the matrix is actually needed.}
 \item{max_iterations}{The maximum number of iterations that the optimization
 algorithm may run through before stopping.}
 
-\item{partial_solution}{An initial \code{matrix} of species presences and
+\item{partial_solution}{Can be either the result of a previous optimization
+run (see \code{value}) or an (initial) \code{matrix} of species presences and
 absences for each site in the landscape. The total number of presences must
-match the estimated species richness of each site.}
+match the estimated species richness of each site. If a result of a previous
+optimization is used, its \code{optimized_grid} is used as initial matrix and
+its \code{error} data frame will be extended with the new iterations.}
 
 \item{fixed_species}{Fixed partial solution with species that are considered
 as given. Those species are not going to be changed during optimization.}
@@ -42,7 +45,8 @@ as given. Those species are not going to be changed during optimization.}
 \item{verbose}{If \code{TRUE} (default), a progress report is printed during
 the optimization run.}
 
-\item{interruptible}{Allow a run to be interrupted before completion.}
+\item{interruptible}{Allow a run to be interrupted before completion.
+\code{FALSE} increases the performance.#'}
 }
 \value{
 A species presence/absence \code{matrix} of the study landscape.

--- a/man/spectre.Rd
+++ b/man/spectre.Rd
@@ -8,6 +8,14 @@
 \description{
 The goal of \code{spectre} is to provide an open source tool capable of predicting regional community composition at fine spatial resolutions using only sparse biological and environmental data.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/r-spatialecology/spectre/}
+  \item Report bugs at \url{https://github.com/r-spatialecology/spectre/issues/}
+}
+
+}
 \author{
 \strong{Maintainer}: Craig Simpkins \email{simpkinscraig063@gmail.com}
 


### PR DESCRIPTION
run_optimization_min_conf now allows the continuation of a previous optimization run. Just use the previous result as value for the `partial_solution` argument.

Example:
```
result_25 <- spectre::run_optimization_min_conf(alpha_list = alpha_list,
                                                 total_gamma = estimated_gamma,
                                                 target = target_matrix,
                                                 max_iterations = 25)

result_100 <- spectre::run_optimization_min_conf(alpha_list = alpha_list,
                                                   total_gamma = estimated_gamma,
                                                   target = target_matrix,
                                                   max_iterations = 75,
                                                   partial_solution = result_25)
```

The difference to `partial_solution = result_25$optimized_grid` is that the error data frame contains the iterations of the previous optimization.

Please check and improve the documentation before pulling. 